### PR TITLE
Fix compatibility with litespeed server

### DIFF
--- a/cgic.c
+++ b/cgic.c
@@ -1873,6 +1873,7 @@ void cgiHeaderCookieSetString(char *name, char *value, int secondsToLive,
 }
 
 void cgiHeaderLocation(char *redirectUrl) {
+	fprintf(cgiOut, "Status: 303 Redirecting\r\n"); // neccesary on some servers, eg litespeed
 	fprintf(cgiOut, "Location: %s\r\n\r\n", redirectUrl);
 }
 

--- a/wfm.c
+++ b/wfm.c
@@ -221,7 +221,7 @@ void checkfilename(char *inp_filename) {
 
     snprintf(temp_dirname, sizeof(temp_dirname), "%s", wp.phys_filename);
     if(strlen(dirname(temp_dirname)) < strlen(cfg.homedir)) 
-        error("Basename path too short");
+        error("Requested path basename ('%s') does not start with the homedir string ('%s'), assuming access is not allowed.");
 }
 
 //

--- a/wfm.c
+++ b/wfm.c
@@ -545,6 +545,10 @@ void cfgload(void) {
     if(strlen(cfg.tagline)>2) cfg.tagline[strlen(cfg.tagline)-1]='\0';
     if(strlen(cfg.favicon)>2) cfg.favicon[strlen(cfg.favicon)-1]='\0';
     
+    // remove trailing slash from homedir (causes problems with basename checks)
+    if(cfg.homedir[strlen(cfg.homedir)-1] == '/')
+        cfg.homedir[strlen(cfg.homedir)-1] = '\0';
+
     // do checks
     if(strlen(cfg.homedir) < 4)
         error("Home directory not defined.");


### PR DESCRIPTION
Unfortunately this PR includes the commits from #37 too.  Ping me if you need them split, git is twisting my mind.

From main commit:

>  cgic.c: make cgiHeaderLocation() compatible with litespeed webserver
>     
>     Context note: I am also going to try and get this changed merged upstream (https://github.com/boutell/cgic), however cgic is not a very active project and this issue is currently preventing me from using wfm on some of my clients' hosts.  Due to the popularity litespeed with shared/cpanel hosting I suspect that other users will be affected by this.
>     
>     Litespeed (for better or for worse):
>      - demands a HTTP 'Status:' be provided by CGI applications
>      - sends users to a non-descript '500 error' page if this is not done
>      - hides the cause of these problems in a shared error log (mostly not user-accessible)
>      - is used on many (most?) shared hosting platforms.
>     
>     In effect: wfm appears to crash after performing several actions (upload file, delete file, probably others) when being used with litespeed.  Users have little/no hope of accessing the relevant logfiles telling them what went wrong as (in the hosts I have encountered) they are not provided per-user, are difficult for support to sift through to find XYZ user's error and cannot be shared with users because of security concerns.  Litespeed itself is claiming there is an error, wfm itself is not crashing, so redirecting errors does not help.

